### PR TITLE
fix typo in transmission-2.0.vapi

### DIFF
--- a/vapi/transmission-2.0.vapi
+++ b/vapi/transmission-2.0.vapi
@@ -714,7 +714,7 @@ namespace Transmission {
 		 * Use of the incomplete download folder
 		 */
 		public bool use_incomplete_dir {
-			[CCode (cname = "tr_seesionSetIncompleteDirEnabled")]
+			[CCode (cname = "tr_sessionSetIncompleteDirEnabled")]
 			set;
 			[CCode (cname = "tr_sessionIsIncompleteDirEnabled")]
 			get;


### PR DESCRIPTION
tr_seesionSetIncompleteDirEnabled → tr_sessionSetIncompleteDirEnabled