### PR TITLE
Better handle when torrent ETA is unknown

### DIFF
--- a/src/Widgets/TorrentListRow.vala
+++ b/src/Widgets/TorrentListRow.vala
@@ -174,7 +174,10 @@ public class Torrential.Widgets.TorrentListRow : Gtk.ListBoxRow {
         var str_seconds = ngettext ("%u second", "%u seconds", seconds).printf (seconds);
 
         var formatted = "";
-        if (days > 0) {
+        if (totalSeconds == -1) {
+            formatted = "...";
+        }
+        else if (days > 0) {
             formatted = "%s, %s, %s, %s".printf (str_days, str_hours, str_minutes, str_seconds);
         }
         else if (hours > 0) {

--- a/src/Widgets/TorrentListRow.vala
+++ b/src/Widgets/TorrentListRow.vala
@@ -176,21 +176,17 @@ public class Torrential.Widgets.TorrentListRow : Gtk.ListBoxRow {
         var formatted = "";
         if (days > 0) {
             formatted = "%s, %s, %s, %s".printf (str_days, str_hours, str_minutes, str_seconds);
-            return formatted;
         }
-        if (hours > 0) {
+        else if (hours > 0) {
             formatted = "%s, %s, %s".printf (str_hours, str_minutes, str_seconds);
-            return formatted;
         }
-        if (minutes > 0) {
+        else if (minutes > 0) {
             formatted = "%s, %s".printf (str_minutes, str_seconds);
-            return formatted;
         }
-        if (seconds > 0) {
+        else if (seconds > 0) {
             formatted = str_seconds;
-            return formatted;
         }
-        return "";
+        return formatted;
     }
 
     private void toggle_pause () {


### PR DESCRIPTION
The `seconds_remaining` getter returns `-1` if it can't get the eta, this makes the interface show `6 hours, 28 minutes, 15 seconds remaining`. Instead, showing `...` makes more sense rather than displaying an inaccurate time.

I also re-factored the logic a little bit so there is only one return statement.