### PR TITLE
Add option to remove torrent and delete files

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -322,7 +322,7 @@ public class Torrential.MainWindow : Gtk.Window {
 
     private void build_main_interface () {
         list_box = new Widgets.TorrentListBox (torrent_manager.get_torrents ());
-        list_box.torrent_removed.connect ((torrent) => torrent_manager.remove_torrent (torrent));
+        list_box.torrent_removed.connect ((torrent, delete_files) => torrent_manager.remove_torrent (torrent, delete_files));
         list_box.open_torrent.connect ((id) => torrent_manager.open_torrent (id));
         list_box.open_torrent_location.connect ((id) => torrent_manager.open_torrent_location (id));
         list_box.link_copied.connect (on_link_copied);

--- a/src/Torrent.vala
+++ b/src/Torrent.vala
@@ -231,8 +231,8 @@ public class Torrential.Torrent {
         torrent.start ();
     }
 
-    public void remove () {
-        torrent.remove (false, null);
+    public void remove (bool delete_files) {
+        torrent.remove (delete_files, null);
     }
 
     public Torrent (Transmission.Torrent torrent) {

--- a/src/TorrentManager.vala
+++ b/src/TorrentManager.vala
@@ -252,14 +252,14 @@ public class Torrential.TorrentManager : Object {
         }
     }
 
-    public void remove_torrent (Torrent to_remove) {
+    public void remove_torrent (Torrent to_remove, bool delete_files) {
         foreach (unowned Transmission.Torrent torrent in added_torrents) {
             if (torrent.id == to_remove.id) {
                 added_torrents.remove (torrent);
                 break;
             }
         }
-        to_remove.remove ();
+        to_remove.remove (delete_files);
     }
 
     private void on_completeness_changed (Transmission.Torrent torrent, Transmission.Completeness completeness, bool wasRunning) {

--- a/src/Widgets/TorrentListBox.vala
+++ b/src/Widgets/TorrentListBox.vala
@@ -21,7 +21,7 @@
 
 public class Torrential.Widgets.TorrentListBox : Gtk.ListBox {
 
-    public signal void torrent_removed (Torrent torrent);
+    public signal void torrent_removed (Torrent torrent, bool delete_files);
     public signal void open_torrent (int id);
     public signal void open_torrent_location (int id);
     public signal void link_copied ();
@@ -61,7 +61,7 @@ public class Torrential.Widgets.TorrentListBox : Gtk.ListBox {
 
     private void add_row (Torrent torrent) {
         var row = new TorrentListRow (torrent);
-        row.torrent_removed.connect ((torrent_to_remove) => torrent_removed (torrent_to_remove));
+        row.torrent_removed.connect ((torrent_to_remove, delete_files) => torrent_removed (torrent_to_remove, delete_files));
         add (row);
     }
 
@@ -108,7 +108,14 @@ public class Torrential.Widgets.TorrentListBox : Gtk.ListBox {
         var remove_item = new Gtk.MenuItem.with_label (_("Remove"));
         remove_item.activate.connect (() => {
             foreach (var selected_row in items) {
-                (selected_row as TorrentListRow).remove_torrent ();
+                (selected_row as TorrentListRow).remove_torrent (false);
+            }
+        });
+
+        var remove_with_files_item = new Gtk.MenuItem.with_label (_("Remove and delete files"));
+        remove_with_files_item.activate.connect (() => {
+            foreach (var selected_row in items) {
+                (selected_row as TorrentListRow).remove_torrent (true);
             }
         });
 
@@ -152,6 +159,7 @@ public class Torrential.Widgets.TorrentListBox : Gtk.ListBox {
         });
 
         menu.add (remove_item);
+        menu.add (remove_with_files_item);
         if (all_paused) {
             menu.add (unpause_item);
         } else {

--- a/src/Widgets/TorrentListRow.vala
+++ b/src/Widgets/TorrentListRow.vala
@@ -32,7 +32,7 @@ public class Torrential.Widgets.TorrentListRow : Gtk.ListBoxRow {
     private const string PAUSE_ICON_NAME = "media-playback-pause-symbolic";
     private const string RESUME_ICON_NAME = "media-playback-start-symbolic";
 
-    public signal void torrent_removed (Torrent torrent);
+    public signal void torrent_removed (Torrent torrent, bool delete_files);
 
     public bool multi_file_torrent {
         get {
@@ -204,8 +204,8 @@ public class Torrential.Widgets.TorrentListRow : Gtk.ListBoxRow {
         }
     }
 
-    public void remove_torrent () {
-        torrent_removed (torrent);
+    public void remove_torrent (bool delete_files) {
+        torrent_removed (torrent, delete_files);
         destroy ();
     }
 


### PR DESCRIPTION
Fixes:  #67 

Note: `delete_files` is a required argument so this needs to be added in code in #120.