### PR TITLE
Play video from folder

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -325,6 +325,7 @@ public class Torrential.MainWindow : Gtk.Window {
         list_box.torrent_removed.connect ((torrent) => torrent_manager.remove_torrent (torrent));
         list_box.open_torrent.connect ((id) => torrent_manager.open_torrent (id));
         list_box.open_torrent_location.connect ((id) => torrent_manager.open_torrent_location (id));
+        list_box.open_torrent_file.connect ((id, file_name) => torrent_manager.open_torrent_file (id, file_name));
         list_box.link_copied.connect (on_link_copied);
         list_box_scroll = new Gtk.ScrolledWindow (null, null);
         list_box_scroll.add (list_box);

--- a/src/TorrentManager.vala
+++ b/src/TorrentManager.vala
@@ -274,23 +274,11 @@ public class Torrential.TorrentManager : Object {
                 if (torrent.stat.activity == Transmission.Activity.SEED && torrent.info.files.length == 1) {
                     var files = torrent.info.files;
                     if (files != null && files.length > 0) {
-                    bool certain = false;
-                    var content_type = ContentType.guess (files[0].name, null, out certain);
-                        var appinfo = AppInfo.get_default_for_type (content_type, true);
-                        if (appinfo != null) {
-                            var path = Path.build_path (Path.DIR_SEPARATOR_S, torrent.download_dir, files[0].name);
-                            var file = File.new_for_path (path);
-                            if (file.query_exists ()) {
-                                var file_list = new List<string> ();
-                                file_list.append (file.get_uri ());
-                                try {
-                                    appinfo.launch_uris (file_list, null);
-                                    return;
-                                } catch (Error e) {
-                                    warning ("Unable to launch default handler for %s, falling back to file manager", content_type);
-                                    open_torrent_location (torrent_id);
-                                }
-                            }
+                        var file_name = files[0].name;
+                        var path = Path.build_path (Path.DIR_SEPARATOR_S, torrent.download_dir, file_name);
+                        var success = open_file (path);
+                        if (success) {
+                            return;
                         }
                     }
                 }
@@ -351,6 +339,38 @@ public class Torrential.TorrentManager : Object {
                 break;
             }
         }
+    }
+
+    public void open_torrent_file (int torrent_id, string file_name) {
+        foreach (unowned Transmission.Torrent torrent in added_torrents) {
+            if (torrent.id == torrent_id) {
+                if (torrent.stat.activity == Transmission.Activity.SEED) {
+                    var path = Path.build_path (Path.DIR_SEPARATOR_S, torrent.download_dir, file_name);
+                    open_file (path);
+                }
+                break;
+            }
+        }
+    }
+
+    private bool open_file (string file_path) {
+        bool certain = false;
+        var content_type = ContentType.guess (file_path, null, out certain);
+        var appinfo = AppInfo.get_default_for_type (content_type, true);
+        if (appinfo != null) {
+            var file = File.new_for_path (file_path);
+            if (file.query_exists ()) {
+                var file_list = new List<string> ();
+                file_list.append (file.get_uri ());
+                try {
+                    appinfo.launch_uris (file_list, null);
+                    return true;
+                } catch (Error e) {
+                    warning ("Unable to launch default handler for %s", content_type);
+                }
+            }
+        }
+        return false;
     }
 
     public float get_overall_progress () {

--- a/src/Widgets/TorrentListBox.vala
+++ b/src/Widgets/TorrentListBox.vala
@@ -24,6 +24,7 @@ public class Torrential.Widgets.TorrentListBox : Gtk.ListBox {
     public signal void torrent_removed (Torrent torrent);
     public signal void open_torrent (int id);
     public signal void open_torrent_location (int id);
+    public signal void open_torrent_file (int id, string file_name);
     public signal void link_copied ();
 
     public enum FilterType {
@@ -138,7 +139,8 @@ public class Torrential.Widgets.TorrentListBox : Gtk.ListBox {
         play_item.activate.connect (() => {
             var selected_row = get_selected_row () as TorrentListRow;
             if (selected_row != null) {
-                debug ("play video: %s", selected_row.playable_file_name);
+                var file_name = selected_row.playable_file_name;
+                open_torrent_file (selected_row.id, file_name);
             }
         });
 

--- a/src/Widgets/TorrentListBox.vala
+++ b/src/Widgets/TorrentListBox.vala
@@ -134,6 +134,14 @@ public class Torrential.Widgets.TorrentListBox : Gtk.ListBox {
             }
         });
 
+        var play_item = new Gtk.MenuItem.with_label (_("Play video"));
+        play_item.activate.connect (() => {
+            var selected_row = get_selected_row () as TorrentListRow;
+            if (selected_row != null) {
+                debug ("play video: %s", selected_row.playable_file_name);
+            }
+        });
+
         var open_item = new Gtk.MenuItem.with_label (_("Show in File Browser"));
         open_item.activate.connect (() => {
             var selected_row = get_selected_row ();
@@ -161,8 +169,14 @@ public class Torrential.Widgets.TorrentListBox : Gtk.ListBox {
         if (items.length () < 2) {
             var selected_row = get_selected_row () as TorrentListRow;
 
-            if (selected_row != null && selected_row.multi_file_torrent) {
-                menu.add (edit_files_item);
+            if (selected_row != null) {
+                if (selected_row.multi_file_torrent) {
+                    menu.add (edit_files_item);
+                }
+
+                if (selected_row.is_playable) {
+                    menu.add (play_item);
+                }
             }
 
             menu.add (copy_magnet_item);

--- a/src/Widgets/TorrentListRow.vala
+++ b/src/Widgets/TorrentListRow.vala
@@ -39,6 +39,8 @@ public class Torrential.Widgets.TorrentListRow : Gtk.ListBoxRow {
             return torrent.file_count > 1;
         }
     }
+    public bool is_playable;
+    public string playable_file_name;
 
     public TorrentListRow (Torrent torrent) {
         this.torrent = torrent;
@@ -123,6 +125,26 @@ public class Torrential.Widgets.TorrentListRow : Gtk.ListBoxRow {
             progress.get_style_context ().add_provider (green_progress_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER);
         } else {
             progress.get_style_context ().remove_provider (green_progress_provider);
+        }
+
+        // check for playable files
+        if (torrent.files != null && torrent.progress == 1 && !is_playable) {
+            for (int i = 0; i < torrent.file_count; i++) {
+                var file = torrent.files [i];
+                bool certain = false;
+                var content_type = ContentType.guess (file.name, null, out certain);
+                // TODO What if guessed content_type is invalid?
+                var super_type = content_type.split ("/")[0];
+                switch (super_type) {
+                    case "video":
+                        is_playable = true;
+                        // store first playable file
+                        if (playable_file_name == null) {
+                            playable_file_name = file.name;
+                        }
+                        break;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
It's quite common that video torrents are folders with the video file. I'm trying to make it easier to play that video from Torrential without having to deal with files.
Fixes: #107 

An alternative approach might be to have an easier / quicker way to open a specific file in a folder, for example by showing the file tree in a menu somewhere.

ToDo:
- [x] Determine if torrent is playable
- [x] Add play video option to context menu
- [x] Open video in default video application