### PR TITLE
Show status info while a new torrent is being checked

### DIFF
--- a/src/Torrent.vala
+++ b/src/Torrent.vala
@@ -110,6 +110,16 @@ public class Torrential.Torrent {
         }
     }
 
+    public bool checking {
+        get {
+            if (torrent.stat_cached != null) {
+                return torrent.stat_cached.activity == Transmission.Activity.CHECK;
+            } else {
+                return false;
+            }
+        }
+    }
+
     public bool downloading {
         get {
             if (torrent.stat_cached != null) {
@@ -134,7 +144,8 @@ public class Torrential.Torrent {
         get {
             if (torrent.stat_cached != null) {
                 return torrent.stat_cached.activity == Transmission.Activity.DOWNLOAD_WAIT ||
-                       torrent.stat_cached.activity == Transmission.Activity.SEED_WAIT;
+                       torrent.stat_cached.activity == Transmission.Activity.SEED_WAIT ||
+                       torrent.stat_cached.activity == Transmission.Activity.CHECK_WAIT;
             } else {
                 return false;
             }


### PR DESCRIPTION
This is my first contribution to an open source project of any kind, so forgive me if I've made some obvious errors. I'm pretty new to Vala, but I've done a decent amount of OO programming, and I'm excited to break into software development.

This pull request is to fix #126. When a new torrent is added that has existing data on disk, the progress bar will turn yellow with the status text "Checking".

Implementing this required reworking the way CSS is applied to the progress bar in `TorrentListRow`, by adding the `Gtk.CssProvider` to the progress bar when it is initialized and simply updating the style as needed when `update()` is called.

This results in much less code duplication, though it may be inefficient if `CssProvier`'s `load_from_data()` method is particularly expensive. I'm quite new to GTK.

I've tested it on my own system and everything seems to look good, though this request adds a new string that will need translation.

I've also attached a screenshot to give you an idea of what it looks like.
![Screenshot from 2019-03-16 12 31 47](https://user-images.githubusercontent.com/48600976/54479961-eb7be800-47f0-11e9-94a1-a3c3d862019e.png)
