### PR TITLE
fixing clipboard pasting for magnet url

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -455,7 +455,6 @@ public class Torrential.MainWindow : Gtk.Window {
         var clipboard = Gtk.Clipboard.get (Gdk.SELECTION_CLIPBOARD);
         string? contents = clipboard.wait_for_text ();
         if (contents != null && contents.has_prefix ("magnet:")) {
-
             entry.text = contents;
         }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -454,7 +454,8 @@ public class Torrential.MainWindow : Gtk.Window {
 
         var clipboard = Gtk.Clipboard.get (Gdk.SELECTION_CLIPBOARD);
         string? contents = clipboard.wait_for_text ();
-        if (contents != null || contents != "") {
+        if (contents != null && contents.has_prefix ("magnet:")) {
+
             entry.text = contents;
         }
 


### PR DESCRIPTION
When adding a new magnet url the entry box would get pasted anything from the clipboard. Changed it so it looks for magnet: prefix.