### PR TITLE
Add launchable tag to appdata

### DIFF
--- a/data/com.github.davidmhewitt.torrential.appdata.xml
+++ b/data/com.github.davidmhewitt.torrential.appdata.xml
@@ -2,6 +2,7 @@
 <!-- Copyright 2017 David Hewitt <davidmhewitt@gmail.com> -->
 <component type="desktop">
   <id>com.github.davidmhewitt.torrential</id>
+  <launchable type="desktop-id">com.github.davidmhewitt.torrential.desktop</launchable>
   <metadata_license>CC0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <name>Torrential</name>


### PR DESCRIPTION
This is needed for appstream-generator to find the associated desktop file.

See also:
- https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable
- https://github.com/ximion/appstream-generator/issues/88