### PR TITLE
PreferencesWindow: code style, Gtk4 prep

### DIFF
--- a/src/PreferencesWindow.vala
+++ b/src/PreferencesWindow.vala
@@ -34,41 +34,31 @@ public class Torrential.PreferencesWindow : Granite.Dialog {
     construct {
         // Window properties
         title = _("Preferences");
-        set_size_request (MIN_WIDTH, MIN_HEIGHT);
+        set_default_size (MIN_WIDTH, MIN_HEIGHT);
         resizable = false;
-        deletable = false;
         destroy_with_parent = true;
-        window_position = Gtk.WindowPosition.CENTER;
         set_transient_for (parent_window);
 
         var stack = new Gtk.Stack ();
         stack.add_titled (create_general_settings_widgets (), "general", _("General"));
         stack.add_titled (create_advanced_settings_widgets (), "advanced", _("Advanced"));
 
-        var switcher = new Gtk.StackSwitcher ();
-        switcher.hexpand = true;
-        switcher.halign = Gtk.Align.CENTER;
-        switcher.margin_start = 20;
-        switcher.margin_end = 20;
-        switcher.set_stack (stack);
+        var switcher = new Gtk.StackSwitcher () {
+            halign = Gtk.Align.CENTER,
+            stack = stack
+        };
 
-        var close_button = new Gtk.Button.with_label (_("Close"));
+        var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        box.add (switcher);
+        box.add (stack);
+
+        get_content_area ().add (box);
+
+        var close_button = (Gtk.Button) add_button (_("Close"), Gtk.ResponseType.CLOSE);
         close_button.clicked.connect (() => {
             on_close ();
-            this.destroy ();
+            destroy ();
         });
-
-        var button_box = new Gtk.ButtonBox (Gtk.Orientation.HORIZONTAL);
-        button_box.margin_end = 10;
-        button_box.set_layout (Gtk.ButtonBoxStyle.END);
-        button_box.pack_end (close_button);
-
-        var content_grid = new Gtk.Grid ();
-        content_grid.attach (switcher, 0, 0, 1, 1);
-        content_grid.attach (stack, 0, 1, 1, 1);
-        content_grid.attach (button_box, 0, 2, 1, 1);
-
-        ((Gtk.Container) get_content_area ()).add (content_grid);
 
         saved_state.changed.connect (on_saved_settings_changed);
     }


### PR DESCRIPTION
Clean up and Gtk 4 prep
* Use default size so we don't hardcode a minimum size
* Granite.Dialog already hides the close button, so this allows closing with `esc`
* Can't set our own window position in Gtk4, should center parent anyways
* Remove a lot of unnecessary properties from the switcher. Halign does what we need
* Box instead of Grid
* Use `add_button` from dialog instead of creating another action area
* Remove unnecessary cast