### PR TITLE
Application: use startup

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -71,8 +71,6 @@ public class Torrential.MainWindow : Gtk.ApplicationWindow {
 
         this.torrent_manager = torrent_manager;
 
-        Gtk.IconTheme.get_default ().add_resource_path ("/com/github/davidmhewitt/torrential");
-
         settings = new GLib.Settings ("com.github.davidmhewitt.torrential.settings");
 
         set_default_size (


### PR DESCRIPTION
* Make sure the stuff we do once happens in `startup` instead of on every activate or every new window
* Use `active_window` from Gtk.Application instead of caching it again ourselves