### PR TITLE
Dialogs: connect to response, use present

### DIFF
--- a/src/Dialogs/FileSelectDialog.vala
+++ b/src/Dialogs/FileSelectDialog.vala
@@ -39,7 +39,8 @@ public class Torrential.Dialogs.FileSelectDialog : Granite.Dialog {
         var view = new Widgets.FileSelectTreeView (torrent);
 
         var scrolled = new Gtk.ScrolledWindow (null, null) {
-            expand = true,
+            hexpand = true,
+            vexpand = true,
             margin_end = 10,
             margin_bottom = 9,
             margin_start = 10

--- a/src/Dialogs/FileSelectDialog.vala
+++ b/src/Dialogs/FileSelectDialog.vala
@@ -40,7 +40,9 @@ public class Torrential.Dialogs.FileSelectDialog : Granite.Dialog {
 
         var scrolled = new Gtk.ScrolledWindow (null, null) {
             expand = true,
-            margin = 6,
+            margin_end = 10,
+            margin_bottom = 9,
+            margin_start = 10
         };
         scrolled.add (view);
         scrolled.get_style_context ().add_class (Gtk.STYLE_CLASS_FRAME);

--- a/src/Dialogs/FileSelectDialog.vala
+++ b/src/Dialogs/FileSelectDialog.vala
@@ -34,18 +34,19 @@ public class Torrential.Dialogs.FileSelectDialog : Granite.Dialog {
     }
 
     construct {
-        deletable = false;
         set_default_size (450, 300);
 
         var view = new Widgets.FileSelectTreeView (torrent);
-        var scrolled = new Gtk.ScrolledWindow (null, null);
-        scrolled.margin = 6;
-        scrolled.shadow_type = Gtk.ShadowType.IN;
-        scrolled.expand = true;
-        scrolled.add (view);
 
-        Gtk.Box content = get_content_area () as Gtk.Box;
-        content.pack_start (scrolled, true, true, 0);
+        var scrolled = new Gtk.ScrolledWindow (null, null) {
+            expand = true,
+            margin = 6,
+        };
+        scrolled.add (view);
+        scrolled.get_style_context ().add_class (Gtk.STYLE_CLASS_FRAME);
+        scrolled.show_all ();
+
+        get_content_area ().add (scrolled);
 
         add_button (_("Close"), 0);
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -355,21 +355,26 @@ public class Torrential.MainWindow : Gtk.ApplicationWindow {
     }
 
     private void on_open (SimpleAction action) {
-        var filech = new Gtk.FileChooserNative (_("Open some torrents"), this, Gtk.FileChooserAction.OPEN, _("Open"), _("Cancel"));
-        filech.set_select_multiple (true);
-
         var all_files_filter = new Gtk.FileFilter ();
         all_files_filter.set_filter_name (_("All files"));
         all_files_filter.add_pattern ("*");
+
         var torrent_files_filter = new Gtk.FileFilter ();
         torrent_files_filter.set_filter_name (_("Torrent files"));
         torrent_files_filter.add_mime_type ("application/x-bittorrent");
+
+        var filech = new Gtk.FileChooserNative (_("Open some torrents"), this, Gtk.FileChooserAction.OPEN, _("Open"), _("Cancel"));
+        filech.set_select_multiple (true);
         filech.add_filter (torrent_files_filter);
         filech.add_filter (all_files_filter);
 
-        if (filech.run () == Gtk.ResponseType.ACCEPT) {
-            add_files (filech.get_uris ());
-        }
+        filech.show ();
+
+        filech.response.connect ((response) => {
+            if (response == Gtk.ResponseType.ACCEPT) {
+                add_files (filech.get_uris ());
+            }
+        });
     }
 
     private void on_open_magnet () {

--- a/src/PreferencesWindow.vala
+++ b/src/PreferencesWindow.vala
@@ -118,14 +118,15 @@ public class Torrential.PreferencesWindow : Granite.Dialog {
                 _("Cancel"), Gtk.ResponseType.CANCEL,
                 _("Select"), Gtk.ResponseType.ACCEPT
             );
+            chooser.present ();
 
-            var res = chooser.run ();
+            chooser.response.connect ((response) => {
+                if (response == Gtk.ResponseType.ACCEPT) {
+                    settings.set_string ("download-folder", chooser.get_file ().get_path ());
+                }
 
-            if (res == Gtk.ResponseType.ACCEPT) {
-                settings.set_string ("download-folder", chooser.get_file ().get_path ());
-            }
-
-            chooser.destroy ();
+                chooser.destroy ();
+            });
         });
 
         location_chooser_label = new Gtk.Label (Utils.get_downloads_folder ());

--- a/src/Widgets/TorrentListRow.vala
+++ b/src/Widgets/TorrentListRow.vala
@@ -129,9 +129,8 @@ public class Torrential.Widgets.TorrentListRow : Gtk.ListBoxRow {
 
     public void edit_files () {
         var dialog = new Dialogs.FileSelectDialog (torrent);
-        dialog.show_all ();
-        dialog.run ();
-        dialog.destroy ();
+        dialog.present ();
+        dialog.response.connect (dialog.destroy);
     }
 
     private string generate_completeness_text () {

--- a/src/Widgets/TorrentListRow.vala
+++ b/src/Widgets/TorrentListRow.vala
@@ -128,7 +128,9 @@ public class Torrential.Widgets.TorrentListRow : Gtk.ListBoxRow {
     }
 
     public void edit_files () {
-        var dialog = new Dialogs.FileSelectDialog (torrent);
+        var dialog = new Dialogs.FileSelectDialog (torrent) {
+            transient_for = (Gtk.Window) get_toplevel ()
+        };
         dialog.present ();
         dialog.response.connect (dialog.destroy);
     }


### PR DESCRIPTION
* `dialog.run ()` doesn't exist in Gtk 4
* Since we remove a `show_all` in the file select dialog, do things there to fix showing the widgets
* While we're touching the file select dialog, fix margins, parent (they're weird values, but I promise it renders correctly)