### PR TITLE
MultiInfoBar: subclass box

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -116,10 +116,7 @@ public class Torrential.MainWindow : Gtk.ApplicationWindow {
         });
         actions.add_action (filter_action);
 
-        infobar = new Widgets.MultiInfoBar () {
-            revealed = false,
-            message_type = Gtk.MessageType.WARNING
-        };
+        infobar = new Widgets.MultiInfoBar ();
 
         list_box = new Widgets.TorrentListBox (torrent_manager.get_torrents ());
         list_box.torrent_removed.connect ((torrent) => torrent_manager.remove_torrent (torrent));

--- a/src/Widgets/MultiInfoBar.vala
+++ b/src/Widgets/MultiInfoBar.vala
@@ -19,20 +19,31 @@
 * Authored by: David Hewitt <davidmhewitt@gmail.com>
 */
 
-public class Torrential.Widgets.MultiInfoBar : Gtk.InfoBar {
-    private Gtk.Label infobar_label = new Gtk.Label ("");
+public class Torrential.Widgets.MultiInfoBar : Gtk.Box {
+    private Gtk.Label infobar_label;
     private Gee.ArrayQueue<string> infobar_errors = new Gee.ArrayQueue<string> ();
     private Gtk.Button next_button;
+    private Gtk.InfoBar infobar;
 
     construct {
-        get_content_area ().add (infobar_label);
+        infobar_label = new Gtk.Label ("") {
+            wrap = true,
+            xalign = 0
+        };
 
-        next_button = (Gtk.Button) add_button (_("Next Warning"), 0);
+        infobar = new Gtk.InfoBar () {
+            message_type = Gtk.MessageType.WARNING,
+            revealed = false
+        };
+        infobar.get_content_area ().add (infobar_label);
+
+        next_button = (Gtk.Button) infobar.add_button (_("Next Warning"), 0);
         next_button.clicked.connect (() => next_error ());
 
-        var close_button = (Gtk.Button) add_button (_("Close"), Gtk.ResponseType.CLOSE);
+        var close_button = (Gtk.Button) infobar.add_button (_("Close"), Gtk.ResponseType.CLOSE);
         close_button.clicked.connect (() => close_bar ());
 
+        add (infobar);
         show_all ();
     }
 
@@ -54,7 +65,7 @@ public class Torrential.Widgets.MultiInfoBar : Gtk.InfoBar {
     }
 
     private void close_bar () {
-        revealed = false;
+        infobar.revealed = false;
         infobar_errors.clear ();
     }
 
@@ -69,7 +80,7 @@ public class Torrential.Widgets.MultiInfoBar : Gtk.InfoBar {
                 next_button.hide ();
             }
             infobar_label.show ();
-            revealed = true;
+            infobar.revealed = true;
         }
     }
 }


### PR DESCRIPTION
Gtk4 prep. Can't subclass InfoBar in Gtk4. While we're here, make sure that label wraps at small sizes